### PR TITLE
Postgis Version 2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,13 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/
 # Install ``python-software-properties``, ``software-properties-common`` and PostgreSQL 9.5
 #  There are some warnings (in red) that show up during the build. You can hide
 #  them by prefixing each apt-get statement with DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y python-software-properties software-properties-common postgresql-9.5 postgresql-contrib-9.5 postgresql-9.5-postgis-2.2 postgis 
+RUN apt-get update && apt-get install -y postgresql-9.5 postgresql-contrib-9.5 postgresql-9.5-postgis-2.2 postgis-2.2
 
 # Note: The official Debian and Ubuntu images automatically ``apt-get clean``
 # after each ``apt-get``
 
 #Setting correct locale for db
-
-RUN pg_dropcluster 9.6 main
+RUN pg_dropcluster 9.2 main
 RUN pg_dropcluster 9.5 main && pg_createcluster --locale en_US.UTF-8 9.5 main -p 5432
 
 # Run the rest of the commands as the ``postgres`` user created by the ``postgres-9.5`` package when it was ``apt-get installed``


### PR DESCRIPTION
# WHAT?
Ensure we use same postgis version as heroku does. [Supported Database Version](https://devcenter.heroku.com/articles/rails-database-connection-behavior)
Heroku Version:
```bash
POSTGIS="2.2.2 r14797" GEOS="3.4.2-CAPI-1.8.2 r3921" PROJ="Rel. 4.8.0, 6 March 2012" GDAL="GDAL 1.10.1, released 2013/08/26" LIBXML="2.9.1" LIBJSON="0.11.99" RASTER 
```

Docker container is using 
```bash 
POSTGIS="2.3.3 xxx" GEOS="3.4.2-CAPI-1.8.2 r3921" PROJ="Rel. 4.8.0, 6 March 2012" GDAL="GDAL 1.10.1, released 2013/08/26" LIBXML="2.9.1" LIBJSON="0.11.99" RASTER 
```

# HOW to build this container?
```bash
docker buid . -t psql
```
Change image of postgres service in docker-compose.yml of the [Devops-Repo](https://github.com/trecker-com/devops) to psql like

```YAML
postgres:
    #image: 552796280524.dkr.ecr.eu-central-1.amazonaws.com/populated.postgis:latest
    image: psql:latest
    ports:
      - "5432:5432"
    networks:
      - internal
```